### PR TITLE
test_ransac.pyとransac_solver.pyをpython3.8.2 + open3d 0.10.0で動作するように変更

### DIFF
--- a/solver/test_ransac.py
+++ b/solver/test_ransac.py
@@ -14,15 +14,15 @@ Param={
   "rotate":0,
   "repeat":1}
 
-model=o3d.read_point_cloud("../data/model.ply")
-scene=o3d.read_point_cloud("../data/sample.ply")
+model=o3d.io.read_point_cloud("../data/model.ply")
+scene=o3d.io.read_point_cloud("../data/sample.ply")
 model.paint_uniform_color([1, 0.706, 0])
 scene.paint_uniform_color([0, 0.651, 0.929])
-o3d.draw_geometries([model, scene])
+o3d.visualization.draw_geometries([model, scene])
 
 solver.learn([solver.toNumpy(model)],Param)
 result=solver.solve([solver.toNumpy(scene)],Param)
-print "Score",result["fitness"]
-print "Tmat",result["transform"]
+print("Score",result["fitness"])
+print("Tmat",result["transform"])
 model.transform(result["transform"][0])
-o3d.draw_geometries([model, scene])
+o3d.visualization.draw_geometries([model, scene])

--- a/src/rovi_utils/ransac_solver.py
+++ b/src/rovi_utils/ransac_solver.py
@@ -27,24 +27,24 @@ def toNumpy(pcd):
 
 def fromNumpy(dat):
   d=dat.astype(np.float32)
-  pc=o3.PointCloud()
-  pc.points=o3.Vector3dVector(d)
+  pc=o3.geometry.PointCloud()
+  pc.points=o3.utility.Vector3dVector(d)
   return pc
 
 def _get_features(cloud):
-  o3.estimate_normals(cloud,o3.KDTreeSearchParamRadius(radius=Param["normal_radius"]))
+  o3.geometry.PointCloud.estimate_normals(cloud,o3.geometry.KDTreeSearchParamRadius(radius=Param["normal_radius"]))
   viewpoint=np.array([0.0,0.0,0.0],dtype=float)
-  o3.orient_normals_towards_camera_location(cloud, camera_location=viewpoint)
+  o3.geometry.PointCloud.orient_normals_towards_camera_location(cloud, camera_location=viewpoint)
   nfmin=Param["normal_min_nn"]
   if nfmin<=0: nfmin=1
-  cl,ind=o3.geometry.radius_outlier_removal(cloud,nb_points=nfmin,radius=Param["normal_radius"])
-  nfcl=o3.geometry.select_down_sample(cloud,ind)
+  cl,ind=o3.geometry.PointCloud.remove_radius_outlier(cloud,nb_points=nfmin,radius=Param["normal_radius"])
+  nfcl=o3.geometry.PointCloud.select_by_index(cloud,ind)
   cloud.points=nfcl.points
   cloud.normals=nfcl.normals
   cds=cloud
   if Param["feature_mesh"]>0:
-    cds=o3.voxel_down_sample(cloud,voxel_size=Param["feature_mesh"])
-  return cds,o3.compute_fpfh_feature(cds,o3.KDTreeSearchParamRadius(radius=Param["feature_radius"]))
+    cds=o3.geometry.PointCloud.voxel_down_sample(cloud,voxel_size=Param["feature_mesh"])
+  return cds,o3.registration.compute_fpfh_feature(cds,o3.geometry.KDTreeSearchParamRadius(radius=Param["feature_radius"]))
 
 def learn(datArray,prm):
   global modFtArray,modPcArray,Param
@@ -68,27 +68,27 @@ def solve(datArray,prm):
     scnPcArray.append(pc)
     scnFtArray.append(_get_features(pc))
   tfeat=time.time()-t1
-  print "time for calc feature",tfeat
+  print("time for calc feature",tfeat)
   t1=time.time()
   if Param["repeat"]!=len(score["transform"]):
     n=Param["repeat"]
     score={"transform":[np.eye(4)]*n,"fitness":[None]*n,"rmse":[None]*n}
   for n in range(Param["repeat"]):
     if Param["distance_threshold"]>0:
-      result=o3.registration_ransac_based_on_feature_matching(
+      result=o3.registration.registration_ransac_based_on_feature_matching(
         modFtArray[0][0],scnFtArray[0][0],modFtArray[0][1],scnFtArray[0][1],Param["distance_threshold"],
-        estimation_method=o3.TransformationEstimationPointToPoint(with_scaling=False),
+        estimation_method=o3.registration.TransformationEstimationPointToPoint(with_scaling=False),
         ransac_n=4,
         checkers=[],
-        criteria=o3.RANSACConvergenceCriteria(max_iteration=100000,max_validation=1000))
+        criteria=o3.registration.RANSACConvergenceCriteria(max_iteration=100000,max_validation=1000))
       score["transform"][n]=result.transformation
       score["fitness"][n]=result.fitness
       score["rmse"][n]=result.inlier_rmse
     if Param["icp_threshold"]>0:
-      result=o3.registration_icp(
+      result=o3.registration.registration_icp(
         modPcArray[0],scnPcArray[0],
         Param["icp_threshold"],
-        score["transform"][n],o3.TransformationEstimationPointToPlane())
+        score["transform"][n],o3.registration.TransformationEstimationPointToPlane())
       score["transform"][n]=result.transformation
       score["fitness"][n]=result.fitness
       score["rmse"][n]=result.inlier_rmse
@@ -97,8 +97,7 @@ def solve(datArray,prm):
       score["fitness"].append(result.fitness)
       score["rmse"].append(result.inlier_rmse)
   tmatch=time.time()-t1
-  print "time for feature matching",tmatch
+  print("time for feature matching",tmatch)
   score["tfeat"]=tfeat
   score["tmatch"]=tmatch
   return score
-


### PR DESCRIPTION
test_ransac.pyとransac_solver.pyの関数を書き換えました。
test_ransac.pyからransag_solver.pyを呼び出すにはrovi_utilsをpipにインストールする必要があります。
よろしくお願いします。